### PR TITLE
* Python3: Update code to work with python3

### DIFF
--- a/bin/scfbuild
+++ b/bin/scfbuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import (absolute_import, division, print_function,

--- a/bin/scfbuild
+++ b/bin/scfbuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import (absolute_import, division, print_function,

--- a/scfbuild/builder.py
+++ b/scfbuild/builder.py
@@ -287,8 +287,8 @@ class Builder(object):
         # TODO: The installed version of fontTools doesn't have
         # table__n_a_m_e.setName().
         record = NameRecord()
-        # PyYAML creates strings, force to Unicode
-        record.string = unicode(text)
+        # PyYAML creates strings, which are unicode as of Python3
+        record.string = text
         record.nameID = name_id
         record.platformID = platform_id
         record.platEncID = plat_enc_id

--- a/scfbuild/builder.py
+++ b/scfbuild/builder.py
@@ -288,6 +288,8 @@ class Builder(object):
         # table__n_a_m_e.setName().
         record = NameRecord()
         # PyYAML creates strings, which are unicode as of Python3
+        if sys.version_info.major == 2:
+            text = unicode(text)
         record.string = text
         record.nameID = name_id
         record.platformID = platform_id

--- a/scfbuild/fforge.py
+++ b/scfbuild/fforge.py
@@ -84,7 +84,7 @@ def add_glyphs(font, svg_filepaths, conf):
             u_ids = [int(u_id, 16) for u_id in filename.split("-")]
             # Example: (0x1f441, 0x1f5e8)
 
-            u_str = ''.join(map(unichr, u_ids))
+            u_str = ''.join(map(chr, u_ids))
             # Example: "U\0001f441U\0001f5e8"
 
             # Replace sequences with correct ZWJ/VS16 versions as needed

--- a/scfbuild/fforge.py
+++ b/scfbuild/fforge.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function,
 import logging
 import fontforge
 import psMat
+import sys
 
 from . import util
 from .util import FONT_EM, DEFAULT_GLYPH_WIDTH
@@ -84,7 +85,10 @@ def add_glyphs(font, svg_filepaths, conf):
             u_ids = [int(u_id, 16) for u_id in filename.split("-")]
             # Example: (0x1f441, 0x1f5e8)
 
-            u_str = ''.join(map(chr, u_ids))
+            if sys.version_info.major == 2:
+                u_str = ''.join(map(unichr, u_ids))
+            else:
+                u_str = ''.join(map(chr, u_ids))
             # Example: "U\0001f441U\0001f5e8"
 
             # Replace sequences with correct ZWJ/VS16 versions as needed

--- a/scfbuild/main.py
+++ b/scfbuild/main.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import argparse
-import ruamel.yaml as yaml
+import yaml
 
 from . import __version__
 from .builder import Builder

--- a/scfbuild/main.py
+++ b/scfbuild/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # SCFBuild is released under the GNU General Public License v3.

--- a/scfbuild/main.py
+++ b/scfbuild/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # SCFBuild is released under the GNU General Public License v3.
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import argparse
-import yaml
+import ruamel.yaml as yaml
 
 from . import __version__
 from .builder import Builder

--- a/scfbuild/main.py
+++ b/scfbuild/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # SCFBuild is released under the GNU General Public License v3.

--- a/scfbuild/requirements.txt
+++ b/scfbuild/requirements.txt
@@ -1,0 +1,2 @@
+fonttools>=3.41.2
+PyYAML>=5.1


### PR DESCRIPTION
Close #18 

Note that dependencies are now that fontforge needs to be installed with python3 bindings (`--enable-python-scripting=3`), and `ruamel.yaml` is needed as the yaml library.